### PR TITLE
Adding a utility function to subset RCTD/spacexr object based on spatial spot ids

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -82,3 +82,50 @@ get_class_df <- function(cell_type_names, use_classes = F) {
   }
   return(class_df)
 }
+
+
+#' Subset spatial object to selected barcodes
+#'
+#' Subsets an rctd object based on the input spatial barcode. 
+#' The function subset_rctd subsets the @spatialRNA, @originalSpatialRNA, and @results$weights slots of an RCTD/spacexr object.
+#'
+#' @param rctd_obj An RCTD/spacexr object
+#' @param st_spot_id A vector of scalar character strings that are spatial barcode to keep after subsetting. 
+#' These barcodes should match the spot names in the original spatial object slot of the RCTD/spacexr object used to generate the rctd_obj.
+#'
+#' @return An updated rctd object with rows corresponding only to the barcodes in st_spot_id
+#'
+#' @export
+subset_rctd = function(rctd_obj, st_spot_id){
+    # 1. Report current number of spots.
+    spot_ids_rctd = rownames(rctd_obj@results$weights)
+    message(paste0('Current spatial spot count before subset: ', length(spot_ids_rctd)))
+    
+    # 2. Subset input st_spot_id to only those that are in rctd_obj
+    st_spot_id = intersect(st_spot_id, spot_ids_rctd)
+    
+    # Throw an error if the subset of spot ids is empty.
+    if(length(st_spot_id) == 0){
+        stop('No spot to keep. Please check input st_spot_id. This should be same as the spot barcodes in spatial object used to generate the RCTD/spacexr object.')
+    }
+
+    # A. subset @spatialRNA slot
+    rctd_obj@spatialRNA@coords = rctd_obj@spatialRNA@coords[st_spot_id, ]
+    rctd_obj@spatialRNA@counts = rctd_obj@spatialRNA@counts[, st_spot_id]
+    rctd_obj@spatialRNA@nUMI   = rctd_obj@spatialRNA@nUMI[st_spot_id]
+
+    # B. subset @originalSpatial slot
+    rctd_obj@originalSpatialRNA@coords = rctd_obj@originalSpatialRNA@coords[st_spot_id, ]
+    rctd_obj@originalSpatialRNA@counts = rctd_obj@originalSpatialRNA@counts[, st_spot_id]
+    rctd_obj@originalSpatialRNA@nUMI   = rctd_obj@originalSpatialRNA@nUMI[st_spot_id]
+
+    # C. Subset @results$weights
+    rctd_obj@results$weights = rctd_obj@results$weights[st_spot_id, ]
+    
+    # 3. Report new number of spots after the subset has been done.
+    spot_ids_rctd_new = rownames(rctd_obj@results$weights)
+    message(paste0('New spatial spot count size after subset: ', length(spot_ids_rctd_new)))
+
+    # Return the resulting subset of the object.
+    return(rctd_obj)
+}


### PR DESCRIPTION
Hi Spacexr team,

Thanks for the great tool! In some scenario I realize I want to subset the resulting RCTD/spacexr object based on the desired spatial barcode id to make the downstream processing smoother. So I wrote this simple subset function that essentially subset following 3 slots

1. @spatialRNA
2. @originalSpatialRNA
3. @results$weights
to match spots provided by user
a example using (using Visium seurat object) would be
```R
rctd_obj = readRDS('path/to/rctd_object.rds')
st_obj = readRDS('path/to/visium_seurat_object.rds')
spot_ids_keep = colnames(st_obj)[1:300]
rctd_obj_new = subset(rctd_obj, spot_ids_keep)
```

Hope this make sense and could benefit other user too. Please let me know if you have any questions or suggestions for improvement!

Thanks,

Simon