### PR TITLE
Speed improvements

### DIFF
--- a/R/IRWLS.R
+++ b/R/IRWLS.R
@@ -34,13 +34,11 @@ solveIRWLS.weights <-function(S,B,nUMI, OLS=FALSE, constrain = TRUE, verbose = F
   #solution <- runif(length(solution))*2 / length(solution) # random initialization
   names(solution) <- colnames(S)
 
-  S_mat <<- matrix(0,nrow = dim(S)[1],ncol = dim(S)[2]*(dim(S)[2] + 1)/2)
-  counter = 1
-  for(i in 1:dim(S)[2])
-    for(j in i:dim(S)[2]) {
-      S_mat[,counter] <<- S[,i] * S[,j] # depends on n^2
-      counter <- counter + 1
-    }
+  numCols <- ncol(S)
+  Index <- which(upper.tri(matrix(0, ncol = numCols, nrow = numCols), diag = TRUE), arr.ind = TRUE)
+  Index <- Index[order(Index[, 1], Index[, 2]), ,drop=F]
+  S_mat <<- S[, Index[, 1]] * S[, Index[, 2]]
+
 
   iterations<-0 #now use dampened WLS, iterate weights until convergence
   changes<-c()
@@ -83,7 +81,7 @@ solveWLS<-function(S,B,initialSol, nUMI, bulk_mode = F, constrain = F){
   threshold = max(1e-4, nUMI * 1e-7)
   prediction[prediction < threshold] <- threshold
   gene_list = rownames(S)
-  derivatives <- get_der_fast(S, B, gene_list, prediction, bulk_mode = bulk_mode)
+  derivatives <- get_der_fast(S, B, gene_list, prediction[,1], bulk_mode = bulk_mode)
   d_vec <- -derivatives$grad
   D_mat <- psd(derivatives$hess)
   norm_factor <- norm(D_mat,"2")

--- a/R/platform_effect_normalization.R
+++ b/R/platform_effect_normalization.R
@@ -82,7 +82,7 @@ choose_sigma_c <- function(RCTD) {
   Q_mat_all <- c(Q1, Q2, Q3, Q4, Q5)
   sigma_vals <- names(Q_mat_all)
 
-  X_vals <- readRDS(system.file("extdata", "Qmat/X_vals.rds", package = "spacexrHD"))
+  X_vals <- readRDS(system.file("extdata", "Qmat/X_vals.rds", package = "spacexr"))
 
   #get initial classification
   N_fit = min(RCTD@config$N_fit,sum(puck@nUMI > MIN_UMI))

--- a/R/platform_effect_normalization.R
+++ b/R/platform_effect_normalization.R
@@ -73,11 +73,11 @@ choose_sigma_c <- function(RCTD) {
   MIN_UMI <- RCTD@config$UMI_min_sigma
   sigma <- 100
 
-  Q1 <- readRDS(system.file("extdata", "Qmat/Q_mat_1.rds", package = "spacexrHD"))
-  Q2 <- readRDS(system.file("extdata", "Qmat/Q_mat_2.rds", package = "spacexrHD"))
-  Q3 <- readRDS(system.file("extdata", "Qmat/Q_mat_3.rds", package = "spacexrHD"))
-  Q4 <- readRDS(system.file("extdata", "Qmat/Q_mat_4.rds", package = "spacexrHD"))
-  Q5 <- readRDS(system.file("extdata", "Qmat/Q_mat_5.rds", package = "spacexrHD"))
+  Q1 <- readRDS(system.file("extdata", "Qmat/Q_mat_1.rds", package = "spacexr"))
+  Q2 <- readRDS(system.file("extdata", "Qmat/Q_mat_2.rds", package = "spacexr"))
+  Q3 <- readRDS(system.file("extdata", "Qmat/Q_mat_3.rds", package = "spacexr"))
+  Q4 <- readRDS(system.file("extdata", "Qmat/Q_mat_4.rds", package = "spacexr"))
+  Q5 <- readRDS(system.file("extdata", "Qmat/Q_mat_5.rds", package = "spacexr"))
 
   Q_mat_all <- c(Q1, Q2, Q3, Q4, Q5)
   sigma_vals <- names(Q_mat_all)

--- a/R/platform_effect_normalization.R
+++ b/R/platform_effect_normalization.R
@@ -107,3 +107,130 @@ choose_sigma_c <- function(RCTD) {
   RCTD@internal_vars$X_vals <- X_vals
   return(RCTD)
 }
+
+#' Estimates sigma_c by maximum likelihood (multi-core)
+#'
+#' @param RCTD an \code{\linkS4class{RCTD}} object after running the \code{\link{fitBulk}} function.
+#' @return Returns an \code{\linkS4class{RCTD}} with the estimated \code{sigma_c}.
+#' @export
+choose_sigma_mc<-function(RCTD)
+{
+  message('Step 2/4: Choose Sigma')
+  puck <- RCTD@spatialRNA
+  MIN_UMI <- RCTD@config$UMI_min_sigma
+  sigma <- 100
+
+  Q1 <- readRDS(system.file("extdata", "Qmat/Q_mat_1.rds", package = "spacexrHD"))
+  Q2 <- readRDS(system.file("extdata", "Qmat/Q_mat_2.rds", package = "spacexrHD"))
+  Q3 <- readRDS(system.file("extdata", "Qmat/Q_mat_3.rds", package = "spacexrHD"))
+  Q4 <- readRDS(system.file("extdata", "Qmat/Q_mat_4.rds", package = "spacexrHD"))
+  Q5 <- readRDS(system.file("extdata", "Qmat/Q_mat_5.rds", package = "spacexrHD"))
+
+  Q_mat_all <- c(Q1, Q2, Q3, Q4, Q5)
+  sigma_vals <- names(Q_mat_all)
+
+  X_vals <- readRDS(system.file("extdata", "Qmat/X_vals.rds", package = "spacexrHD"))
+
+  #get initial classification
+  N_fit = min(RCTD@config$N_fit,sum(puck@nUMI > MIN_UMI))
+  if(N_fit == 0) {
+    stop(paste('choose_sigma_c determined a N_fit of 0! This is probably due to unusually low UMI counts per bead in your dataset. Try decreasing the parameter UMI_min_sigma. It currently is',MIN_UMI,'but none of the beads had counts larger than that.'))
+  }
+
+  fit_ind = sample(names(puck@nUMI[puck@nUMI > MIN_UMI]), N_fit)
+  beads = t(puck@counts[RCTD@internal_vars$gene_list_reg,fit_ind])
+
+  #message(paste('chooseSigma: using initial Q_mat with sigma = ',sigma/100))
+  #print(paste0("N_epoch: ",RCTD@config$N_epoch))
+
+  nUMI <- puck@nUMI[fit_ind]
+  cell_type_means <- RCTD@cell_type_info$renorm[[1]]
+  gene_list <- RCTD@internal_vars$gene_list_reg
+  constrain <- FALSE
+  max_cores <- RCTD@config$max_cores
+
+  if(max_cores > 1)
+  {
+    message(paste0("Multicore enabled using ", max_cores," cores"))
+    registerDoParallel(cores=max_cores)
+  }
+
+  NN<-nrow(beads)
+  pb <- txtProgressBar(min = 0, max = RCTD@config$N_epoch, style = 3)
+
+  for(iter in 1:RCTD@config$N_epoch)
+  {
+    set_likelihood_vars(Q_mat_all[[as.character(sigma)]], X_vals)
+
+    if(max_cores>1)
+    {
+
+      results<- foreach(i = 1:NN) %dopar% {
+
+        #set_likelihood_vars(Q_mat_all[[as.character(sigma)]], X_vals)
+        weights <- solveIRWLS.weights(data.matrix(RCTD@cell_type_info$renorm[[1]][RCTD@internal_vars$gene_list_reg,]*nUMI[i]),
+                                      beads[i,],
+                                      nUMI[i],
+                                      OLS = FALSE,
+                                      constrain = FALSE,
+                                      verbose = FALSE,
+                                      n.iter = 50,
+                                      MIN_CHANGE = 0.001,
+                                      bulk_mode = FALSE)
+
+        return(weights)
+      }
+
+
+    }else{
+
+      results<-vector("list",length=nrow(beads))
+
+      for(i in 1:nrow(beads))
+      {
+        set_likelihood_vars(Q_mat_all[[as.character(sigma)]], X_vals)
+        weights <- solveIRWLS.weights(data.matrix(RCTD@cell_type_info$renorm[[1]][RCTD@internal_vars$gene_list_reg,]*nUMI[i]),
+                                      beads[i,],
+                                      nUMI[i],
+                                      OLS = FALSE,
+                                      constrain = FALSE,
+                                      verbose = FALSE,
+                                      n.iter = 50,
+                                      MIN_CHANGE = 0.001,
+                                      bulk_mode = FALSE)
+        results[[i]]<-weights
+
+      }
+
+
+    }
+
+    weights<- do.call(rbind,lapply(results,function(X){return(X$weights)}))
+    weights<-as(weights,"dgCMatrix")
+    rownames(weights) <- fit_ind
+    colnames(weights) <- RCTD@cell_type_info$renorm[[2]]
+    prediction <- sweep(as.matrix(RCTD@cell_type_info$renorm[[1]][RCTD@internal_vars$gene_list_reg,]) %*% t(as.matrix(weights)), 2, puck@nUMI[fit_ind], '*')
+    #message(paste('Likelihood value:',calc_log_l_vec(as.vector(prediction), as.vector(t(beads)))))
+    sigma_prev <- sigma
+    sigma <- chooseSigma(prediction, t(beads), Q_mat_all, X_vals, sigma)
+
+    if(sigma == sigma_prev)
+    {
+      message(paste0(RCTD@config$N_epoch,"/",RCTD@config$N_epoch))
+      break
+    }
+
+    setTxtProgressBar(pb, iter)
+  }
+
+  setTxtProgressBar(pb, iter)
+
+  close(pb)
+  RCTD@internal_vars$sigma <- sigma/100
+  RCTD@internal_vars$Q_mat <- Q_mat_all[[as.character(sigma)]]
+  RCTD@internal_vars$X_vals <- X_vals
+
+  return(RCTD)
+
+
+}

--- a/R/platform_effect_normalization.R
+++ b/R/platform_effect_normalization.R
@@ -67,54 +67,7 @@ chooseSigma <- function(prediction, counts, Q_mat_all, X_vals, sigma) {
 #' @return Returns an \code{\linkS4class{RCTD}} with the estimated \code{sigma_c}.
 #' @export
 choose_sigma_c <- function(RCTD) {
-  puck = RCTD@spatialRNA; MIN_UMI = RCTD@config$UMI_min_sigma; sigma = 100
-  #Q_mat_all <- readRDS('/Users/dcable/Documents/MIT/Research/Rafalab/Projects/slideseq/Cell Demixing/ContentStructure/RCTD/Qmat/Q_mat_c.rds')
-  Q1 <- readRDS(system.file("extdata", "Qmat/Q_mat_1.rds", package = "spacexr"))
-  Q2 <- readRDS(system.file("extdata", "Qmat/Q_mat_2.rds", package = "spacexr"))
-  Q3 <- readRDS(system.file("extdata", "Qmat/Q_mat_3.rds", package = "spacexr"))
-  Q4 <- readRDS(system.file("extdata", "Qmat/Q_mat_4.rds", package = "spacexr"))
-  Q5 <- readRDS(system.file("extdata", "Qmat/Q_mat_5.rds", package = "spacexr"))
-  Q_mat_all <- c(Q1, Q2, Q3, Q4, Q5)
-  sigma_vals <- names(Q_mat_all)
-  #X_vals <- readRDS('/Users/dcable/Documents/MIT/Research/Rafalab/Projects/slideseq/Cell Demixing/ContentStructure/RCTD/Qmat/X_vals.rds')
-  X_vals <- readRDS(system.file("extdata", "Qmat/X_vals.rds", package = "spacexr"))
-  #get initial classification
-  N_fit = min(RCTD@config$N_fit,sum(puck@nUMI > MIN_UMI))
-  if(N_fit == 0) {
-      stop(paste('choose_sigma_c determined a N_fit of 0! This is probably due to unusually low UMI counts per bead in your dataset. Try decreasing the parameter UMI_min_sigma. It currently is',MIN_UMI,'but none of the beads had counts larger than that.'))
-  }
-  fit_ind = sample(names(puck@nUMI[puck@nUMI > MIN_UMI]), N_fit)
-  beads = t(as.matrix(puck@counts[RCTD@internal_vars$gene_list_reg,fit_ind]))
-  message(paste('chooseSigma: using initial Q_mat with sigma = ',sigma/100))
-  for(iter in 1:RCTD@config$N_epoch) {
-    set_likelihood_vars(Q_mat_all[[as.character(sigma)]], X_vals)
-    #message(paste('chooseSigma: getting initial weights for #samples: ',N_fit))
-    results = decompose_batch(puck@nUMI[fit_ind], RCTD@cell_type_info$renorm[[1]], beads, RCTD@internal_vars$gene_list_reg, constrain = F, max_cores = RCTD@config$max_cores)
-    weights = Matrix(0, nrow = N_fit, ncol = RCTD@cell_type_info$renorm[[3]])
-    rownames(weights) = fit_ind; colnames(weights) = RCTD@cell_type_info$renorm[[2]];
-    for(i in 1:N_fit)
-      weights[i,] = results[[i]]$weights
-    prediction <- sweep(as.matrix(RCTD@cell_type_info$renorm[[1]][RCTD@internal_vars$gene_list_reg,]) %*% t(as.matrix(weights)), 2, puck@nUMI[fit_ind], '*')
-    message(paste('Likelihood value:',calc_log_l_vec(as.vector(prediction), as.vector(t(beads)))))
-    sigma_prev <- sigma
-    sigma <- chooseSigma(prediction, t(beads), Q_mat_all, X_vals, sigma)
-    message(paste('Sigma value: ', sigma/100))
-    if(sigma == sigma_prev)
-      break
-  }
-  RCTD@internal_vars$sigma <- sigma/100
-  RCTD@internal_vars$Q_mat <- Q_mat_all[[as.character(sigma)]]
-  RCTD@internal_vars$X_vals <- X_vals
-  return(RCTD)
-}
-
-#' Estimates sigma_c by maximum likelihood (multi-core)
-#'
-#' @param RCTD an \code{\linkS4class{RCTD}} object after running the \code{\link{fitBulk}} function.
-#' @return Returns an \code{\linkS4class{RCTD}} with the estimated \code{sigma_c}.
-#' @export
-choose_sigma_mc<-function(RCTD)
-{
+  
   message('Step 2/4: Choose Sigma')
   puck <- RCTD@spatialRNA
   MIN_UMI <- RCTD@config$UMI_min_sigma
@@ -231,6 +184,4 @@ choose_sigma_mc<-function(RCTD)
   RCTD@internal_vars$X_vals <- X_vals
 
   return(RCTD)
-
-
 }

--- a/R/postProcessing.R
+++ b/R/postProcessing.R
@@ -2,39 +2,44 @@
 
 # Collects RCTD results
 gather_results <- function(RCTD, results) {
-  cell_type_names = RCTD@cell_type_info$renorm[[2]]
+
+  message('Step 4/4: Gather Results')
+  pb <- txtProgressBar(max = 3, style = 3)
+
+  cell_type_names <- RCTD@cell_type_info$renorm[[2]]
   barcodes <- colnames(RCTD@spatialRNA@counts)
   N <- length(results)
-  weights = Matrix(0, nrow = N, ncol = length(cell_type_names))
-  weights_doublet = Matrix(0, nrow = N, ncol = 2)
-  rownames(weights) = barcodes; rownames(weights_doublet) = barcodes
-  colnames(weights) = cell_type_names; colnames(weights_doublet) = c('first_type', 'second_type')
-  empty_cell_types = factor(character(N),levels = cell_type_names)
+
+  empty_cell_types <- factor(character(N),levels = cell_type_names)
   spot_levels <- c("reject", "singlet", "doublet_certain", "doublet_uncertain")
-  results_df <- data.frame(spot_class = factor(character(N),levels=spot_levels),
-                           first_type = empty_cell_types, second_type = empty_cell_types,
-                           first_class = logical(N), second_class = logical(N),
-                           min_score = numeric(N), singlet_score = numeric(N),
-                           conv_all = logical(N), conv_doublet = logical(N))
-  score_mat <- list()
-  singlet_scores <- list()
-  for(i in 1:N) {
-    if(i %% 1000 == 0)
-      print(paste("gather_results: finished",i))
-    weights_doublet[i,] = results[[i]]$doublet_weights
-    weights[i,] = results[[i]]$all_weights
-    results_df[i, "spot_class"] = results[[i]]$spot_class
-    results_df[i, "first_type"] = results[[i]]$first_type
-    results_df[i, "second_type"] = results[[i]]$second_type
-    results_df[i, "first_class"] = results[[i]]$first_class
-    results_df[i, "second_class"] = results[[i]]$second_class
-    results_df[i, "min_score"] = results[[i]]$min_score
-    results_df[i, "singlet_score"] = results[[i]]$singlet_score
-    results_df[i, "conv_all"] = results[[i]]$conv_all
-    results_df[i, "conv_doublet"] = results[[i]]$conv_doublet
-    score_mat[[i]] <- results[[i]]$score_mat
-    singlet_scores[[i]] <- results[[i]]$singlet_scores
-  }
+
+  setTxtProgressBar(pb, 1)
+  
+  results_df <- data.frame(spot_class = factor(sapply(results,function(X){return(X$spot_class)}),levels=spot_levels),
+                           first_type = sapply(results,function(X){return(X$first_type)}),
+                           scond_type = sapply(results,function(X){return(X$second_type)}),
+                           first_class = sapply(results,function(X){return(X$first_class)}),
+                           second_class = sapply(results,function(X){return(X$second_class)}),
+                           min_score = sapply(results,function(X){return(X$min_score)}),
+                           singlet_score = sapply(results,function(X){return(X$singlet_score)}),
+                           conv_all = sapply(results,function(X){return(X$conv_all)}),
+                           conv_doublet = sapply(results,function(X){return(X$conv_doublet)}))
+
+  setTxtProgressBar(pb, 2)
+
+  weights_doublet <- do.call(rbind,lapply(results,function(X){return(X$doublet_weights)}))
+  weights <- do.call(rbind,lapply(results,function(X){return(X$all_weights)}))
+
+  rownames(weights) <- barcodes
+  rownames(weights_doublet) <- barcodes
+  colnames(weights) <- cell_type_names
+  colnames(weights_doublet) <- c('first_type', 'second_type')
+
+  score_mat <- lapply(results,function(X){return(X$score_mat)})
+  singlet_scores <- lapply(results,function(X){return(X$singlet_scores)})
+
+  setTxtProgressBar(pb, 3)
+
   rownames(results_df) = barcodes
   RCTD@results <- list(results_df = results_df, weights = weights, weights_doublet = weights_doublet,
                        score_mat = score_mat, singlet_scores = singlet_scores)

--- a/R/prob_model.R
+++ b/R/prob_model.R
@@ -127,21 +127,37 @@ calc_Q_all <- function(Y, lambda) {
   epsilon <- 1e-4; X_max <- max(X_vals); delta <- 1e-6
   lambda <- pmin(pmax(epsilon, lambda),X_max - epsilon)
 
-  l <- floor((lambda/delta)^(1/2))
-  m <- pmin(l - 9,40) + pmax(ceiling(sqrt(pmax(l-48.7499,0)*4))-2,0)
-  ti1 <- X_vals[m]; ti <- X_vals[m+1]; hi <- ti - ti1
-  #Q0 <- cbind(Y+1, m); Q1 <- cbind(Y+1, m+1)
-  Q0 <- cbind(Y+1, m); Q1 <- Q0; Q1[,2] <- Q1[,2] + 1
-  fti1 <- Q_mat[Q0]; fti <- Q_mat[Q1]
-  zi1 <- SQ_mat[Q0]; zi <- SQ_mat[Q1]
-  diff1 <- lambda - ti1; diff2 <- ti - lambda
-  diff3 <- fti/hi-zi*hi/6; diff4 <- fti1/hi-zi1*hi/6
-  zdi <- zi / hi; zdi1 <- zi1 / hi
+  l <- floor(sqrt(lambda / delta))
+  V1 <- pmin(40, l - 9)
+  V2 <- pmax(0, ceiling(sqrt(pmax(0, l - 48.7499) * 4)) - 2)
+  m <- V1 + V2
+
+  ti1 <- X_vals[m]
+  ti <- X_vals[m + 1]
+  hi <- ti - ti1
+
+  Q0 <- cbind(Y+1, m)
+  Q1 <- Q0
+  Q1[,2] <- Q1[,2] + 1
+  fti1 <- Q_mat[Q0]
+  fti <- Q_mat[Q1]
+  zi1 <- SQ_mat[Q0]
+  zi <- SQ_mat[Q1]
+
+  diff1 <- lambda - ti1
+  diff2 <- ti - lambda
+  diff3 <- fti / hi - zi * hi / 6
+  diff4 <- fti1 / hi - zi1 * hi / 6
+  zdi <- zi / hi
+  zdi1 <- zi1 / hi
+
   # cubic spline interpolation
   d0_vec <- zdi*(diff1)^3/6 + zdi1*(diff2)^3/6 + diff3*diff1 + diff4*diff2
   d1_vec <- zdi*(diff1)^2/2 - zdi1*(diff2)^2/2 + diff3 - diff4
   d2_vec <- zdi*(diff1) + zdi1*(diff2)
+
   return(list(d0_vec = d0_vec, d1_vec = d1_vec, d2_vec = d2_vec))
+
 }
 
 #negative log likelihood

--- a/R/spacexr.R
+++ b/R/spacexr.R
@@ -41,12 +41,12 @@ process_cell_type_info <- function(reference, cell_type_names, CELL_MIN = 25) {
 #' @return an \code{\linkS4class{RCTD}} object, which is ready to run the \code{\link{run.RCTD}} function
 #' @export
 create.RCTD <- function(spatialRNA, reference, max_cores = 4, test_mode = FALSE, gene_cutoff = 0.000125, fc_cutoff = 0.5, gene_cutoff_reg = 0.0002, fc_cutoff_reg = 0.75, UMI_min = 100, UMI_max = 20000000, counts_MIN = 10, UMI_min_sigma = 300,
-                         class_df = NULL, CELL_MIN_INSTANCE = 25, cell_type_names = NULL, MAX_MULTI_TYPES = 4, keep_reference = F, cell_type_profiles = NULL, CONFIDENCE_THRESHOLD = 5, DOUBLET_THRESHOLD = 20) {
+                         class_df = NULL, CELL_MIN_INSTANCE = 25, cell_type_names = NULL, MAX_MULTI_TYPES = 4, keep_reference = F, cell_type_profiles = NULL, CONFIDENCE_THRESHOLD = 5, DOUBLET_THRESHOLD = 20, MIN_OBS = 3) {
 
    config <- list(gene_cutoff = gene_cutoff, fc_cutoff = fc_cutoff, gene_cutoff_reg = gene_cutoff_reg, fc_cutoff_reg = fc_cutoff_reg, UMI_min = UMI_min, UMI_min_sigma = UMI_min_sigma, max_cores = max_cores,
                  N_epoch = 8, N_X = 50000, K_val = 100, N_fit = 1000, N_epoch_bulk = 30,
                  MIN_CHANGE_BULK = 0.0001, MIN_CHANGE_REG = 0.001, UMI_max = UMI_max, counts_MIN = counts_MIN,
-                 MIN_OBS = 3, MAX_MULTI_TYPES = MAX_MULTI_TYPES, CONFIDENCE_THRESHOLD = CONFIDENCE_THRESHOLD, DOUBLET_THRESHOLD = DOUBLET_THRESHOLD)
+                 MIN_OBS = MIN_OBS, MAX_MULTI_TYPES = MAX_MULTI_TYPES, CONFIDENCE_THRESHOLD = CONFIDENCE_THRESHOLD, DOUBLET_THRESHOLD = DOUBLET_THRESHOLD)
    if(test_mode)
      config <- list(gene_cutoff = .00125, fc_cutoff = 0.5, gene_cutoff_reg = 0.002, fc_cutoff_reg = 0.75, UMI_min = 1000,
           N_epoch = 1, N_X = 50000, K_val = 100, N_fit = 50, N_epoch_bulk = 4, MIN_CHANGE_BULK = 1,


### PR DESCRIPTION
This PR includes a series of commits intended to reduce the computational time when running the algorithm in doublet mode. Mostly intended for high definition assays (big number of spots), but usable with all other methods.

<img width="1088" alt="SpaceXR_SpeedUp" src="https://github.com/dmcable/spacexr/assets/16755507/dd56af0c-341a-42df-858d-32c1e002bd50">


### **_Main changes:_**

**1. Change parallelization approach**
- Use foreach + DoParallel for the multicore implementation. This prevents launching multiple R sessions and we also included a progress bar for a cleaner UI.

**2. Speed up gather_results**
- Bottle neck in the algorithm. Fully vectorized the function to remove unnecessary loops. Added progress bar as well

**3. General speed up**
- Modified existing functions to improve overall performance.

**4. Add MIN_OBS as parameter to create.RCTD**
- Adds MIN_OBS as a variable to allow running in specific scenarios. Allows more control and customized running, but user should be aware of the drawbacks (i.e. sampling noise). Kept the original default value.


### **_To do list:_**

- [ ] Adapt new parallelization approach to other modes (full & multi)
- [ ] Improve screen messages for easier progress tracking