### PR TITLE
exvar.point.density bug fix and run.CSIDE.single error message fix

### DIFF
--- a/R/CSIDE.R
+++ b/R/CSIDE.R
@@ -44,15 +44,15 @@ run.CSIDE.single <- function(myRCTD, explanatory.variable,  cell_types = NULL, c
   region_thresh <- cell_type_threshold / 2
   r1 <- barcodes[X2[,2] < medv]
   if(length(r1) < region_thresh)
-    stop(paste0('run.CSIDE.single: number of pixels with explanatory.variable at least medv = ',medv,
-                " is less than (one half of cell_type_threshold) = ", region_thresh,
-                ". Please make sure that explanatory.variable attains a large value sufficiently often."))
-  cell_type_filter <- aggregate_cell_types(myRCTD, r1, doublet_mode = doublet_mode) >= region_thresh
-  r2 <- barcodes[X2[,2] > medv]
-  if(length(r2) < region_thresh)
     stop(paste0('run.CSIDE.single: number of pixels with explanatory.variable below medv = ',medv,
                 " is less than (one half of cell_type_threshold) = ", region_thresh,
                 ". Please make sure that explanatory.variable attains a small value sufficiently often."))
+  cell_type_filter <- aggregate_cell_types(myRCTD, r1, doublet_mode = doublet_mode) >= region_thresh
+  r2 <- barcodes[X2[,2] > medv]
+  if(length(r2) < region_thresh)
+    stop(paste0('run.CSIDE.single: number of pixels with explanatory.variable above medv = ',medv,
+                " is less than (one half of cell_type_threshold) = ", region_thresh,
+                ". Please make sure that explanatory.variable attains a large value sufficiently often."))
   cell_type_filter <- cell_type_filter & (aggregate_cell_types(myRCTD, r2, doublet_mode = doublet_mode) >= region_thresh)
   message(paste0('run.CSIDE.single: filtered out cell types: ', list(which(!cell_type_filter)),
                  ' due to not having sufficiently many pixels with explanatory.value on either side of medv = ',medv,

--- a/R/CSIDE_utils.R
+++ b/R/CSIDE_utils.R
@@ -426,15 +426,15 @@ exvar.celltocell.interactions <- function(myRCTD, barcodes, cell_type, radius = 
 #' @export
 exvar.point.density <- function(myRCTD, barcodes, points, radius = 50) {
   puck <- myRCTD@spatialRNA
-  explanatory.variable = c(rep(0,length(barcodes)))
-  names(explanatory.variable) = barcodes
+  target_coords <- puck@coords[barcodes, , drop = FALSE]
   # fields::rdist treats rows as coordinates and computes all distances between placing them in a distance matrix.
-  dist_matrix = fields::rdist(as.matrix(puck@coords), as.matrix(points))
-  rownames(dist_matrix) = rownames(puck@coords)
+  dist_matrix <- fields::rdist(as.matrix(target_coords), as.matrix(points))
+  rownames(dist_matrix) <- barcodes
   # Precompute the exponent component of the proximity score for all pairs of cells
-  exponent_mat = exp(-dist_matrix/radius)
+  exponent_mat <- exp(-dist_matrix/radius)
   explanatory.variable <- rowSums(exponent_mat)
-  explanatory.variable = normalize_ev(explanatory.variable)
+  explanatory.variable <- normalize_ev(explanatory.variable)
+  return(explanatory.variable)
 }
 
 # Normalize explanatory.variable so the values span from 0 to 1.


### PR DESCRIPTION
Commit dffa427:
Minor issue with the error thrown in the checks for run.CSIDE.single.
Specifically, the error messages for the medv checks are swapped: r1 checks for pixels < medv, but the stop() message complains about pixels "at least medv". And vice versa for r2.
Proposed change swaps the two error messages.

Commit 8b22881:
Bug: exvar.point.density takes in a list of barcodes (pixels) of the spatialRNA object to be used when constructing the explanatory variable, but overwrites this list and and uses all barcodes (pixels) to construct explanatory variable.
Proposed change subsets using user's input barcodes.

Thanks for the package!